### PR TITLE
Pulled in two patches 

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -21,6 +21,8 @@ ifeq ($(PC_LIBS),)
 endif
 LIBS+=$(PC_LIBS)
 
+wvdial-LIBS+= -luniconf
+
 BINDIR=${prefix}/bin
 MANDIR=${prefix}/share/man
 PPPDIR=/etc/ppp/peers

--- a/wvdial.conf.5
+++ b/wvdial.conf.5
@@ -69,6 +69,11 @@ The speed at which
 .B wvdial
 will communicate with your modem.  The default is 57600 baud.
 .TP
+.I No Hardware Protocol
+If value is set,
+.B wvdial
+will not use hardware protocol for connections.
+.TP
 .I "Init1 ... Init9"
 .B wvdial
 can use up to nine initialization strings to set up your modem.  Before

--- a/wvdialer.h
+++ b/wvdialer.h
@@ -141,6 +141,7 @@ public:
 	int              idle_seconds;
 	int              isdn;
 	int              ask_password;
+	int              no_hardware_protocol;
 	int              dial_timeout;
        
     } options;


### PR DESCRIPTION
Pulled in two patches that let you complete builds on armhf platform, and let you use wvdial to dial up hardware modems over UART using USB - Serial converters without hardware flow control
